### PR TITLE
Intergration LoRA sur le nouveau prototype.

### DIFF
--- a/sondeMultiple
+++ b/sondeMultiple
@@ -137,6 +137,9 @@ void setup(){
 
   Serial.print("U= "); Serial.print(voltage);  Serial.print("V");
   delay(500);
+  
+  
+// The loop function runs over and over again forever
   char c;
   if (SerialLora.available() > 0)
   {

--- a/sondeMultiple
+++ b/sondeMultiple
@@ -1,27 +1,15 @@
 
-HardwareSerial SerialLora(D0, D1);
+
 
 void setup()
 {
-  Serial.begin(115200);
-  SerialLora.begin(115200);
+
 }
 
 // The loop function runs over and over again forever
 void loop()
 {
-  char c;
-
-  if (SerialLora.available() > 0)
-  {
-    c = SerialLora.read();
-    Serial.print(c);
-  }
-  if (Serial.available() > 0)
-  {
-    c = Serial.read();
-    SerialLora.print(c);
-  }
+  
 }
 
 /////////////
@@ -53,6 +41,8 @@ float R1 = 12352.0;
 float R2 = 17647.0;
 float voltage = 0;
 
+//Variables LoRA:
+HardwareSerial SerialLora(D0, D1);
 
 
 ///////////////////////////////
@@ -115,6 +105,12 @@ void setup(){
      //lcd.init();        //I2C 
      //lcd.backlight();   //I2C
      lcd.begin(16,2);
+
+     // Port série pour le LoRA:
+       Serial.begin(115200);
+       SerialLora.begin(115200);
+     
+     
      
 }
 
@@ -141,4 +137,16 @@ void setup(){
 
   Serial.print("U= "); Serial.print(voltage);  Serial.print("V");
   delay(500);
+  char c;
+  if (SerialLora.available() > 0)
+  {
+    c = SerialLora.read();
+    Serial.print(c);
+  }
+  if (Serial.available() > 0)
+  {
+    c = Serial.read();
+    SerialLora.print(c);
+  }
+  
 }

--- a/sondeMultiple
+++ b/sondeMultiple
@@ -1,17 +1,3 @@
-
-
-
-void setup()
-{
-
-}
-
-// The loop function runs over and over again forever
-void loop()
-{
-  
-}
-
 /////////////
 /* INCLUDES:*/
 #include <LiquidCrystal.h>
@@ -20,6 +6,7 @@ void loop()
 // Wiring: SDA pin is connected to A4 and SCL pin to A5.
 // Connect to LCD via I2C, default address 0x27 (A0-A2 not jumpered)
 // LiquidCrystal_I2C.h: https://github.com/johnrickman/LiquidCrystal_I2C
+// 
 
 
 ///////////////

--- a/sondeMultiple
+++ b/sondeMultiple
@@ -1,4 +1,29 @@
 
+HardwareSerial SerialLora(D0, D1);
+
+void setup()
+{
+  Serial.begin(115200);
+  SerialLora.begin(115200);
+}
+
+// The loop function runs over and over again forever
+void loop()
+{
+  char c;
+
+  if (SerialLora.available() > 0)
+  {
+    c = SerialLora.read();
+    Serial.print(c);
+  }
+  if (Serial.available() > 0)
+  {
+    c = Serial.read();
+    SerialLora.print(c);
+  }
+}
+
 /////////////
 /* INCLUDES:*/
 #include <LiquidCrystal.h>


### PR DESCRIPTION
Intergration de la fonctionnalité LoRA. 
/*
Source: https://github.com/stm32duino/I-NUCLEO-LRWAN1/edit/master/examples/BridgeSerial/BridgeSerial.ino

  Allows to relay UART data from/to a PC terminal to/from LORA shield.

  Shield uses a LPUART interface as the AT command console, the D0 and D1 pin
  is the LPUART TX and LPUART RX, and the default configuration is 115200,N,8,1

  Important note for Nucleo64:
  by default, D0/D1 of CN9 board connector are respectively not connected to
  PA3 and PA2 (SB62 and SB63 opened).
  Those pins are connected to STLink USART thanks to SB13, SB14.

  To use the shield:
    - Connect shield D0(Tx) to a free U(S)ARTn Rx pin
    - Connect shield D1(Rx) to a free U(S)ARTn Tx pin
  Where 'n' are the same U(S)ART number
    - Update the below 'SerialLora' instance definition using the chosen Rx/Tx

  or
    - Close SB62 and SB63 to connect D0/D1 of CN9 connector to PA3 and PA2
    - Open SB13 and SB14 to disconnect PA3 and PA2 from STLink UART
  but in this case, you will have to wire STLink Rx/Tx of CN3 connector to
  another pins and update Serial instance before call `Serial.begin(115200);`
  using:
  Serial.setRx(Rx pin);
  Serial.setTx(Tx pin);
*/